### PR TITLE
Development server should listen on 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build this site for local viewing or development:
     $ python setup.py develop
     $ pserve ./development.ini
 
-The site will then be available on your local machine at: [http://0.0.0.0:6543/](http://0.0.0.0:6543/)
+The site will then be available on your local machine at: [http://localhost:6543/](http://localhost:6543/)
 
 ## License
 This repository contains the code of:

--- a/development.ini
+++ b/development.ini
@@ -27,7 +27,7 @@ fanstatic.debug = true
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = 127.0.0.1
 port = 6543
 
 ###


### PR DESCRIPTION
0.0.0.0 means it binds on all interfaces on the machine which is a bit sloppy; the server should only be available on localhost.
